### PR TITLE
Load media on start

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,6 +92,8 @@ CPM_ExportAdditionalDefinition(-DQT_NO_KEYWORDS)
 
 # Disable warnings
 add_definitions(-D_SCL_SECURE_NO_WARNINGS)
+# Specify that we want to export symbols to a DLL (as opposed to importing them from a DLL).
+add_definitions(-DBUILD_BIOTRACKER_DLL)
 
 # include external dependecies as SYSTEM headers to prevent warnings from
 # external files. unfortunately, this has no effect when using MSVC.

--- a/biotracker/BioTrackerApp.h
+++ b/biotracker/BioTrackerApp.h
@@ -9,6 +9,7 @@
 #include <QKeyEvent>
 #include <QMouseEvent>
 
+#include "util/platform.h"
 #include "TrackingThread.h"
 #include "ImageStream.h"
 #include "Registry.h"
@@ -16,11 +17,12 @@
 #include "TrackerStatus.h"
 #include "PanZoomState.h"
 
+
 namespace BioTracker {
 namespace Core {
 
 /* Used to be Facade */
-class BioTrackerApp : public QObject {
+class BIOTRACKER_DLLEXPORT BioTrackerApp : public QObject {
   public:
     Q_OBJECT
   public:

--- a/biotracker/BioTrackerApp.h
+++ b/biotracker/BioTrackerApp.h
@@ -50,6 +50,12 @@ class BIOTRACKER_DLLEXPORT BioTrackerApp : public QObject {
 
     /**
      * @throw boost::filesystem_error
+     * @brief openMediaBySetting opens a medium (camera, images or video) which has been storen in the settings
+     */
+    void openMedumBySetting();
+
+    /**
+     * @throw boost::filesystem_error
      * @brief openVideo opens a single video which type is supported by opencv and stores path in settings
      */
     void openVideo(const boost::filesystem::path &path);

--- a/biotracker/BioTrackerApp.h
+++ b/biotracker/BioTrackerApp.h
@@ -52,7 +52,7 @@ class BIOTRACKER_DLLEXPORT BioTrackerApp : public QObject {
      * @throw boost::filesystem_error
      * @brief openMediaBySetting opens a medium (camera, images or video) which has been storen in the settings
      */
-    void openMedumBySetting();
+    void openMediumBySetting();
 
     /**
      * @throw boost::filesystem_error

--- a/biotracker/Registry.h
+++ b/biotracker/Registry.h
@@ -6,6 +6,7 @@
 
 #include <QObject>
 
+#include "util/platform.h"
 #include "zmq/ZmqInfoFile.h"
 #include "TrackingAlgorithm.h"
 #include "util/stdext.h"
@@ -22,12 +23,12 @@ static const TrackerType NoTracking = 0;
 // construct on first use idiom
 TrackerType getNextId();
 
-struct NewTrackerFactory {
+struct BIOTRACKER_DLLEXPORT NewTrackerFactory {
     virtual std::shared_ptr<TrackingAlgorithm> operator()(Settings &settings) const = 0;
     virtual ~NewTrackerFactory() {}
 };
 
-class Registry : public QObject, public Util::Singleton<Registry> {
+class BIOTRACKER_DLLEXPORT Registry : public QObject, public Util::Singleton<Registry> {
     Q_OBJECT
   public:
     typedef std::map<const TrackerType, std::shared_ptr<NewTrackerFactory>>

--- a/biotracker/TrackingAlgorithm.h
+++ b/biotracker/TrackingAlgorithm.h
@@ -12,6 +12,7 @@
 #include <QPointer>
 #include <QMouseEvent>
 
+#include "util/platform.h"
 #include "settings/Messages.h"
 #include "settings/ParamNames.h"
 #include "serialization/TrackedObject.h"
@@ -55,14 +56,14 @@ class ProxyMat {
     boost::optional<cv::Mat> m_modifiedMat;
 };
 
-class TrackingAlgorithm : public QObject {
+class BIOTRACKER_DLLEXPORT TrackingAlgorithm : public QObject {
     Q_OBJECT
 
   public:
     TrackingAlgorithm(Settings &settings);
     virtual ~TrackingAlgorithm() override;
 
-    struct View {
+    struct BIOTRACKER_DLLEXPORT View {
         std::string name;
     };
 

--- a/biotracker/settings/SystemCompatibilityCheck.h
+++ b/biotracker/settings/SystemCompatibilityCheck.h
@@ -1,10 +1,12 @@
 #pragma once
 
+#include "util/platform.h"
+
 namespace SystemCompatibilityCheck {
 /**
  * Check the system supports openGL.
  * @return true, system supports openGL, false otherwise.
  */
-bool checkOpenGLSupport();
+bool BIOTRACKER_DLLEXPORT checkOpenGLSupport();
 }
 

--- a/biotracker/src/BioTrackerApp.cpp
+++ b/biotracker/src/BioTrackerApp.cpp
@@ -17,6 +17,7 @@ BioTrackerApp::BioTrackerApp()
     loadModulesInPath(ConfigParam::MODULE_PATH);
 
     m_trackingThread.start();
+    m_trackingThread.loadFromSettings();
 }
 
 BioTrackerApp::~BioTrackerApp() {

--- a/biotracker/src/BioTrackerApp.cpp
+++ b/biotracker/src/BioTrackerApp.cpp
@@ -42,7 +42,7 @@ void BioTrackerApp::initConnects() {
                      this, &BioTrackerApp::trackerIsAlreadyLoadedFromRegistry);
 }
 
-void BioTrackerApp::openMedumBySetting() {
+void BioTrackerApp::openMediumBySetting() {
     m_trackingThread.loadFromSettings();
 }
 

--- a/biotracker/src/BioTrackerApp.cpp
+++ b/biotracker/src/BioTrackerApp.cpp
@@ -17,7 +17,6 @@ BioTrackerApp::BioTrackerApp()
     loadModulesInPath(ConfigParam::MODULE_PATH);
 
     m_trackingThread.start();
-    m_trackingThread.loadFromSettings();
 }
 
 BioTrackerApp::~BioTrackerApp() {
@@ -41,6 +40,10 @@ void BioTrackerApp::initConnects() {
 
     QObject::connect(&m_registry, &Core::Registry::trackerIsAlreadyLoaded,
                      this, &BioTrackerApp::trackerIsAlreadyLoadedFromRegistry);
+}
+
+void BioTrackerApp::openMedumBySetting() {
+    m_trackingThread.loadFromSettings();
 }
 
 void BioTrackerApp::openVideo(const boost::filesystem::path &path) {

--- a/biotracker/src/ImageStream.cpp
+++ b/biotracker/src/ImageStream.cpp
@@ -134,6 +134,10 @@ class ImageStreamPictures : public ImageStream {
   public:
     explicit ImageStreamPictures(std::vector<boost::filesystem::path> picture_files)
         : m_picture_files(std::move(picture_files)) {
+        if (m_picture_files.empty()) {
+            throw file_not_found("Could not find any picture files");
+        }
+
         // load first image
         if (this->numFrames() > 0) {
             this->setFrameNumber_impl(0);
@@ -244,7 +248,7 @@ class ImageStreamCamera : public ImageStream {
         : m_capture(device_id)
         , m_fps(m_capture.get(CV_CAP_PROP_FPS)) {
         if (! m_capture.isOpened()) {
-            throw device_open_error(":(");
+            throw device_open_error("Could not open camera " + std::to_string(device_id));
         }
         // load first image
         if (this->numFrames() > 0) {

--- a/biotracker/src/util/stringTools.cpp
+++ b/biotracker/src/util/stringTools.cpp
@@ -4,10 +4,12 @@
 #include <string>    // std::string
 #include <stdexcept> // std::invalid_argument
 
+#include "util/platform.h"
+
 namespace BioTracker {
 namespace Util {
 
-std::string escape_non_ascii(const std::string &s) {
+std::string BIOTRACKER_DLLEXPORT escape_non_ascii(const std::string &s) {
     std::string result;
     for (const auto c : s) {
         // MSB is set --> not a valid ASCII character --> escape
@@ -29,7 +31,7 @@ std::string escape_non_ascii(const std::string &s) {
 }
 
 
-std::string unescape_non_ascii(const std::string &s) {
+std::string BIOTRACKER_DLLEXPORT unescape_non_ascii(const std::string &s) {
 
     const auto advance = [&s](std::string::const_iterator &it) {
         if (++it == s.cend()) {
@@ -78,7 +80,7 @@ std::string unescape_non_ascii(const std::string &s) {
     return result;
 }
 
-std::string stem_filename(const std::string &s) {
+std::string BIOTRACKER_DLLEXPORT stem_filename(const std::string &s) {
     boost::filesystem::path p(s);
     return p.stem().string();
 }

--- a/biotracker/util/platform.h
+++ b/biotracker/util/platform.h
@@ -1,0 +1,14 @@
+#pragma once
+
+/*
+This macro must be used to mark all symbols that should be exported to a DLL.
+*/
+#ifdef _MSC_VER
+#ifdef BUILD_BIOTRACKER_DLL
+#define BIOTRACKER_DLLEXPORT __declspec(dllexport)
+#else
+#define BIOTRACKER_DLLEXPORT __declspec(dllimport)
+#endif
+#else
+#define BIOTRACKER_DLLEXPORT
+#endif


### PR DESCRIPTION
Previously loaded media were loaded again by starting the Biotracker in old Biotracker. This behaviour has been ported to new Biotracker.
