### PR TITLE
Fix building on macOS

### DIFF
--- a/BioTracker/CoreApp/BioTracker/Model/Annotations.cpp
+++ b/BioTracker/CoreApp/BioTracker/Model/Annotations.cpp
@@ -1,6 +1,6 @@
 #include "Annotations.h"
 
-#include <math.h>
+#include <cmath>
 #include <fstream>
 
 Annotations::~Annotations() 


### PR DESCRIPTION
math.h places its functions into the global namespace, not into
namespace std, use cmath instead (see ISO/IEC C++ 2011 §D.5,2).

Preexisting [this](https://github.com/MoritzMaxeiner/biotracker_core/blob/02e132e12f74d4751f953933c00c402201e75853/BioTracker/CoreApp/BioTracker/Model/Annotations.cpp#L116) will lead to compilation error otherwise.