### PR TITLE
Fresh tracks were unable to be saved

### DIFF
--- a/BioTracker/CoreApp/BioTracker/Model/DataExporters/DataExporterCSV.cpp
+++ b/BioTracker/CoreApp/BioTracker/Model/DataExporters/DataExporterCSV.cpp
@@ -225,13 +225,6 @@ void DataExporterCSV::writeAll(std::string f) {
     //Find max length of all tracks
     int max = getMaxLinecount();
 
-    //There is nothing to write
-    if (max <= 1)
-    {
-        cleanup();
-        return;
-    }
-
     std::string target = f;
     if (target.size() <= 4) {
         target = _finalFile;

--- a/BioTracker/CoreApp/BioTracker/Model/DataExporters/DataExporterJson.cpp
+++ b/BioTracker/CoreApp/BioTracker/Model/DataExporters/DataExporterJson.cpp
@@ -176,11 +176,6 @@ void DataExporterJson::writeAll(std::string f) {
         _ofs.close();
     }
 
-    if (getMaxLinecount() <= 1) {
-        cleanup();
-        return;
-    }
-
     std::string target = f;
     if (target.size() <= 1) {
         target = _finalFile;

--- a/BioTracker/CoreApp/BioTracker/Model/DataExporters/DataExporterSerialize.cpp
+++ b/BioTracker/CoreApp/BioTracker/Model/DataExporters/DataExporterSerialize.cpp
@@ -98,11 +98,6 @@ void DataExporterSerialize::writeAll(std::string f) {
         _ofs.close();
     }
 
-    if (getMaxLinecount() <= 1) {
-        cleanup();
-        return;
-    }
-
     std::string target = f;
     if (target.size() <= 1) {
         target = _finalFile;


### PR DESCRIPTION
The deleted code induced #156. Of course, `getMaxLinecount()` returns only 1 when a tracking is not performed yet. I have no idea why that code was there, but it looks to be there intentionaly. So if I've missed something, just dismiss this PR.